### PR TITLE
chore: mbord1の関数名からマジックナンバーを排除

### DIFF
--- a/src/lib/ruby-generator/mboard1.js
+++ b/src/lib/ruby-generator/mboard1.js
@@ -89,15 +89,15 @@ export default function (Generator) {
     };
 
     
-    // メニューについては Ruby 側でも定義が必要のようだ
-    Generator.mboard1_menu_menu1 = function (block) {
-        const menu1 = Generator.getFieldValue(block, 'menu1') || null;
-        return [menu1, Generator.ORDER_ATOMIC];
+    // // メニューについては Ruby 側でも定義が必要のようだ
+    Generator.mboard1_menu_soundMenu = function (block) {
+        const soundMenu = Generator.getFieldValue(block, 'soundMenu') || null;
+        return [soundMenu, Generator.ORDER_ATOMIC];//soundMenuに変更
     };
-    Generator.mboard1_menu_menu2 = function (block) {
-        const menu2 = Generator.getFieldValue(block, 'menu2') || null;
-        return [menu2, Generator.ORDER_ATOMIC];
-    };
+    Generator.mboard1_menu_ledSwMenu = function (block) {
+        const ledSwMenu = Generator.getFieldValue(block, 'ledSwMenu') || null;
+        return [ledSwMenu, Generator.ORDER_ATOMIC];
+    };//LedSwMenuに変更
 
     return Generator;
 }


### PR DESCRIPTION
mboard1.jsの関数名からマジックナンバーを排除した。
index.jsのmenu1,menu2の関数名を変更したため,それに対応するmboard1.jsの関数名もそれぞれ変更した。